### PR TITLE
Documentation improvements.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,34 @@
+This program is free software; you can redistribute it and/or modify it under
+the terms of the the Artistic License (2.0). You may obtain a copy of the full
+license at:
+
+L<http://www.perlfoundation.org/artistic_license_2_0>
+
+Any use, modification, and distribution of the Standard or Modified Versions is
+governed by this Artistic License. By using, modifying or distributing the
+Package, you accept this license. Do not use, modify, or distribute the
+Package, if you do not accept this license.
+
+If your Modified Version has been derived from a Modified Version made by
+someone other than you, you are nevertheless required to ensure that your
+Modified Version complies with the requirements of this license.
+
+This license does not grant you the right to use any trademark, service mark,
+tradename, or logo of the Copyright Holder.
+
+This license includes the non-exclusive, worldwide, free-of-charge patent
+license to make, have made, use, offer to sell, sell, import and otherwise
+transfer the Package with respect to any patent claims licensable by the
+Copyright Holder that are necessarily infringed by the Package. If you
+institute patent litigation (including a cross-claim or counterclaim) against
+any party alleging that the Package constitutes direct or contributory patent
+infringement, then this Artistic License to you shall terminate on the date
+that such litigation is filed.
+
+Disclaimer of Warranty: THE PACKAGE IS PROVIDED BY THE COPYRIGHT HOLDER AND
+CONTRIBUTORS "AS IS' AND WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES. THE IMPLIED
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, OR NON-
+INFRINGEMENT ARE DISCLAIMED TO THE EXTENT PERMITTED BY YOUR LOCAL LAW. UNLESS
+REQUIRED BY LAW, NO COPYRIGHT HOLDER OR CONTRIBUTOR WILL BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL DAMAGES ARISING IN ANY WAY OUT
+OF THE USE OF THE PACKAGE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/MANIFEST
+++ b/MANIFEST
@@ -3,6 +3,7 @@ Changes
 eg/example.pl
 eg/hashexample.pl
 lib/String/Template.pm
+LICENSE
 MANIFEST			This list of files
 META.json
 META.yml

--- a/README
+++ b/README
@@ -6,14 +6,27 @@ Some special formats can impose formatting on the fields.
 
 INSTALLATION
 
-To install this module type the following:
+To install this module, use CPAN, for example:
 
-   perl Makefile.PL
-   make
-   make test
-   make install
+  cpan String::Template
+
+To instead build this software from source, run:
+
+  perl Build.PL
+  ./Build
+  ./Build test
+  ./Build install
+
+After installing, you can read the documentation for this module via:
+
+  perldoc String::Template
 
 DEPENDENCIES
 
 This module requires these other modules and libraries:
   POSIX, Date::Parse, DateTime::Format::Strptime
+
+LICENSE
+
+This program is free software; you can redistribute it and/or modify it
+under the terms of the the Artistic License (2.0).


### PR DESCRIPTION
 * Correct manual build instructions to suit Module::Build, also README
   pointers about installing via the `cpan` command and docs via `perldoc`.
 * Add LICENSE file and brief license blarb to README.