### PR TITLE
Do not need DateTime::Format::Strptime

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -11,9 +11,10 @@ my $builder = Module::Build->new(
     requires => {
         'Date::Parse' => 0,
         POSIX => 0,
-        'DateTime::Format::Strptime' => 0,
     },
     test_requires => {
+        'Test::Pod' => 0,
+        'Test::Pod::Coverage' => 0,
         $^O eq 'MSWin32' ? ('Time::Piece' => '1.17') : (),
     },
     configure_requires => {

--- a/Build.PL
+++ b/Build.PL
@@ -13,8 +13,6 @@ my $builder = Module::Build->new(
         POSIX => 0,
     },
     test_requires => {
-        'Test::Pod' => 0,
-        'Test::Pod::Coverage' => 0,
         $^O eq 'MSWin32' ? ('Time::Piece' => '1.17') : (),
     },
     configure_requires => {

--- a/MANIFEST
+++ b/MANIFEST
@@ -15,3 +15,5 @@ t/Expand.t
 t/expand_hash.t
 t/Insensitive.t
 t/Undef.t
+t/pod-coverage.t
+t/pod.t

--- a/lib/String/Template.pm
+++ b/lib/String/Template.pm
@@ -6,7 +6,6 @@ use warnings;
 use base 'Exporter';
 use POSIX;
 use Date::Parse;
-use DateTime::Format::Strptime;
 
 our @EXPORT = qw(expand_string missing_values expand_stringi);
 our @EXPORT_OK = qw(expand_hash);

--- a/t/pod-coverage.t
+++ b/t/pod-coverage.t
@@ -1,5 +1,5 @@
 #!perl
-use 5.10.0;
+
 use strict;
 use warnings;
 use Test::More;

--- a/t/pod-coverage.t
+++ b/t/pod-coverage.t
@@ -4,6 +4,10 @@ use strict;
 use warnings;
 use Test::More;
 
+unless ( $ENV{RELEASE_TESTING} ) {
+  plan skip_all => 'these tests are for release candidate testing';
+}
+
 # Ensure a recent version of Test::Pod::Coverage
 my $min_tpc = 1.08;
 eval "use Test::Pod::Coverage $min_tpc";
@@ -18,6 +22,4 @@ eval "use Pod::Coverage $min_pc";
 plan skip_all => "Pod::Coverage $min_pc required for testing POD coverage"
   if $@;
 
-# uc named subs include the Moo BUILD and various inlined constant subs, and
-# not anything otherwise documentable.
-all_pod_coverage_ok( { trustme => [ qr/^[A-Z]/ ] } );
+all_pod_coverage_ok();

--- a/t/pod-coverage.t
+++ b/t/pod-coverage.t
@@ -1,0 +1,23 @@
+#!perl
+use 5.10.0;
+use strict;
+use warnings;
+use Test::More;
+
+# Ensure a recent version of Test::Pod::Coverage
+my $min_tpc = 1.08;
+eval "use Test::Pod::Coverage $min_tpc";
+plan skip_all =>
+  "Test::Pod::Coverage $min_tpc required for testing POD coverage"
+  if $@;
+
+# Test::Pod::Coverage doesn't require a minimum Pod::Coverage version,
+# but older versions don't recognize some common documentation styles
+my $min_pc = 0.18;
+eval "use Pod::Coverage $min_pc";
+plan skip_all => "Pod::Coverage $min_pc required for testing POD coverage"
+  if $@;
+
+# uc named subs include the Moo BUILD and various inlined constant subs, and
+# not anything otherwise documentable.
+all_pod_coverage_ok( { trustme => [ qr/^[A-Z]/ ] } );

--- a/t/pod.t
+++ b/t/pod.t
@@ -1,0 +1,12 @@
+#!perl
+use 5.10.0;
+use strict;
+use warnings;
+use Test::More;
+
+# Ensure a recent version of Test::Pod
+my $min_tp = 1.22;
+eval "use Test::Pod $min_tp";
+plan skip_all => "Test::Pod $min_tp required for testing POD" if $@;
+
+all_pod_files_ok();

--- a/t/pod.t
+++ b/t/pod.t
@@ -4,6 +4,10 @@ use strict;
 use warnings;
 use Test::More;
 
+unless ( $ENV{RELEASE_TESTING} ) {
+  plan skip_all => 'these tests are for release candidate testing';
+}
+
 # Ensure a recent version of Test::Pod
 my $min_tp = 1.22;
 eval "use Test::Pod $min_tp";

--- a/t/pod.t
+++ b/t/pod.t
@@ -1,5 +1,5 @@
 #!perl
-use 5.10.0;
+
 use strict;
 use warnings;
 use Test::More;


### PR DESCRIPTION
DateTime::Format::Strptime not needed; POSIX imports a strftime, and tests pass without DateTime::Format::Strptime. Add POD tests (which also all pass).