### PR TITLE
Add support for extended fields using curly braces

### DIFF
--- a/t/extended_field.t
+++ b/t/extended_field.t
@@ -1,0 +1,29 @@
+use strict;
+use warnings;
+use Test::More;
+use String::Template;
+
+my $template = 'I <str{"%s" }>mean literally';
+
+is expand_string( $template, { str => 'literally' } ),
+  'I "literally" mean literally', "Parsed extended field";
+
+is expand_string( $template, { str => undef } ),
+  'I mean literally', "Extended field is treated as a whole";
+
+is expand_string( '<str{"%s"\}}>', { str => 'foo' } ),
+  '"foo"}', "Escaped curly brace";
+
+is expand_string( $template, { str => undef }, 1 ),
+  $template, "Template is unchanged if undefined";
+
+is expand_string( '<str{--#2}>', { str => 'foobar' }, 1 ),
+  '--obar', "Extended substr with undef flag";
+
+is expand_string( '<str{--#2}>', { str => undef } ),
+  q{}, "Extended subtr without undef flag";
+
+is expand_string( '<str{--#1,3}-->', { str => 'foobar' }, 1 ),
+  '--oob--', "Extended field with suffix";
+
+done_testing();


### PR DESCRIPTION
This patch adds support for a new special character: `{`, which makes it possible to add additional content to a field keeping it separate from the format string itself.

In particular, the motivation behind this was to allow for truly optional fields, meaning fields that are entirely ignored if a particular key is missing from the data hash.

To illustrate, with these variables:

``` perl
my $mack = { name => 'Mack', nick    => 'The Knife' };
my $jack = { name => 'Jack', surname => 'Sheppard'  };
```

this is the current behaviour:

``` perl
my $template = '|<name> "<nick>" <surname>|';
expand_string( $template, $mack ); # Returns '|Mack "The Knife" |'
expand_string( $template, $jack ); # Returns '|Jack "" Sheppard|'
```

The current patch makes it possible to do this instead:

``` perl
my $template = '|<name><nick{ "%s"}><surname{ %s}>|';
expand_string( $template, $mack ); # Returns '|Mack "The Knife"|'
expand_string( $template, $jack ); # Returns '|Jack Sheppard|'
```

Internally, this is implemented as a new subroutine in the `%special` hash that parses the content between curly braces and forwards it to the inner special character.
