### PR TITLE
Add support for "tight" extended fields

### DIFF
--- a/lib/String/Template.pm
+++ b/lib/String/Template.pm
@@ -123,7 +123,7 @@ This makes it possible to have templates like this:
  my $jack = { name => 'Jack', surname => 'Sheppard'  };
 
  expand_string( $template, $mack ); # Returns 'Mack "The Knife"'
- expand_string( $template, $jack ); # Returns 'Jack Shepard'
+ expand_string( $template, $jack ); # Returns 'Jack Sheppard'
 
 =cut
 

--- a/lib/String/Template.pm
+++ b/lib/String/Template.pm
@@ -47,7 +47,7 @@ my %special =
 
 my $specials = join('', keys %special);
 my $specialre = qr/^([^{$specials]+)([{$specials])(.+)$/;
-my $bracketre = qr/^([^{$specials]+)([{$specials])(.+)(?<!\\)\}(.*)$/;
+my $bracketre = qr/^([^$specials]*?)([{$specials])(.*?)(?<!\\)\}(.*)$/;
 
 $special{'{'} = sub {
     my ($field, $replace) = @_;

--- a/t/string_template.t
+++ b/t/string_template.t
@@ -116,6 +116,9 @@ subtest 'extended field' => sub {
   is expand_string( '<str{"%s"\}}>', { str => 'foo' } ),
     '"foo"}', "Escaped curly brace";
 
+  is expand_string( '<str{%s}>', { str => 'foo' } ),
+    'foo', "Can have tight extended fields";
+
   is expand_string( $template, { str => undef }, 1 ),
     $template, "Template is unchanged if undefined";
 


### PR DESCRIPTION
The previous implementation made it impossible to have fields like `<foo{%s}>`, which seemed counterintuitive. This patch fixes that

It also fixes a typo in the documentation, introduced by yours truly. :sweat: 